### PR TITLE
Since many hashes changed, pin pillow to fix FOR NOW.

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,1 +1,2 @@
 imagehash>=4.0
+pillow<7


### PR DESCRIPTION
See if this fixes the current test problems.
The change is parallel to https://github.com/SciTools/iris/pull/3630

TODO: 
If this happens again, or when pillow 6 comes to seem hopelessly antiquated, in future we could decide to refresh all the filenames *instead*.
We could easily produce an automated script for that : in practice, we could easily make it an alternate run mode of the "run_test.py" script.
This would require matching changes in Iris whenever we do it.
