### PR TITLE
Fix CI breaking changes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,9 +60,9 @@ linux_task:
       - uname -r
     populate_script:
       - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
-      - conda-lock --mamba --platform linux-64 --file ${YAML_FILE}
+      - conda-lock --kind=explicit --mamba --platform linux-64 --file ${YAML_FILE}
       - mamba create --name ${ENV_NAME} --quiet --file conda-linux-64.lock
       - conda info --envs
   test_script:
     - source activate ${ENV_NAME}
-    - python run_test.py 
+    - python run_test.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.1.0'
+    rev: 'v4.2.0'
     hooks:
         # Prevent giant files from being committed.
     -   id: check-added-large-files
@@ -17,7 +17,7 @@ repos:
         # Don't commit to master branch.
     -   id: no-commit-to-branch
 -   repo: https://github.com/psf/black
-    rev: '22.1.0'
+    rev: '22.3.0'
     hooks:
     -   id: black
         # Force black to run on whole repo, using settings from pyproject.toml


### PR DESCRIPTION
Handles the breaking change from conda-lock `v1.0`. See SciTools/iris#4644.

Handles the breaking change in Black. See SciTools/iris#4668.